### PR TITLE
fix(template): allow all deps to run postinstall scripts

### DIFF
--- a/scripts/create-lang/template/package.json
+++ b/scripts/create-lang/template/package.json
@@ -41,6 +41,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "pnpm": {
-    "neverBuiltDependencies": []
+    "onlyBuiltDependencies": [
+      "tree-sitter-cli"
+    ]
   }
 }

--- a/scripts/create-lang/template/package.json
+++ b/scripts/create-lang/template/package.json
@@ -42,6 +42,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "$$PACKAGE_NAME$$",
       "tree-sitter-cli"
     ]
   }

--- a/scripts/create-lang/template/package.json
+++ b/scripts/create-lang/template/package.json
@@ -39,5 +39,8 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "pnpm": {
+    "neverBuiltDependencies": []
   }
 }


### PR DESCRIPTION
## description

Try to fix the build error when using `pnpm v10` mentioned in #20.

[pnpm/approve-builds](https://pnpm.io/cli/approve-builds)

Related issue of `pnpm`: https://github.com/pnpm/pnpm/issues/9102#issuecomment-2657147365.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the dependency management configuration by adding a new option for the `pnpm` package manager, allowing for more control over built dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->