### PR TITLE
feat: add tree-sitter-c

### DIFF
--- a/packages/c/README.md
+++ b/packages/c/README.md
@@ -1,0 +1,24 @@
+# ast-grep napi language for c
+
+## Installation
+
+In a pnpm project, run:
+
+```bash
+pnpm install @ast-grep/lang-c
+pnpm install @ast-grep/napi
+# install the tree-sitter-cli if no prebuild is available
+pnpm install @tree-sitter/cli --save-dev
+```
+
+## Usage
+
+```js
+import c from '@ast-grep/lang-c'
+import { registerDynamicLanguage, parse } from '@ast-grep/napi'
+
+registerDynamicLanguage({ c })
+
+const sg = parse('c', `your code`)
+sg.root().kind()
+```

--- a/packages/c/index.d.ts
+++ b/packages/c/index.d.ts
@@ -1,0 +1,10 @@
+type LanguageRegistration = {
+  libraryPath: string
+  extensions: string[]
+  languageSymbol?: string
+  metaVarChar?: string
+  expandoChar?: string
+}
+
+declare const registratoin: LanguageRegistration
+export default registratoin

--- a/packages/c/index.js
+++ b/packages/c/index.js
@@ -1,0 +1,9 @@
+const path = require('node:path')
+const libPath = path.join(__dirname, 'parser.so')
+
+module.exports = {
+  libraryPath: libPath,
+  extensions: ["c","h"],
+  languageSymbol: 'tree_sitter_c',
+  expandoChar: '_',
+}

--- a/packages/c/nursery.js
+++ b/packages/c/nursery.js
@@ -1,0 +1,16 @@
+const { setup } = require('@ast-grep/nursery')
+const languageRegistration = require('./index')
+const assert = require('node:assert')
+
+setup({
+  dirname: __dirname,
+  name: 'c',
+  treeSitterPackage: 'tree-sitter-c',
+  languageRegistration,
+  testRunner: (parse) => {
+    const sg = parse('int a = 123;')
+    const root = sg.root()
+    const node = root.find('$T $A = 123')
+    assert.equal(node.kind(), 'declaration')
+  }
+})

--- a/packages/c/package.json
+++ b/packages/c/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@ast-grep/lang-c",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tree-sitter build -o parser.so",
+    "source": "node nursery.js source",
+    "prepublishOnly": "node nursery.js source",
+    "postinstall": "node postinstall.js",
+    "test": "node nursery.js test"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "type.d.ts",
+    "postinstall.js",
+    "src",
+    "prebuilds"
+  ],
+  "keywords": [
+    "ast-grep"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@ast-grep/setup-lang": "0.0.3"
+  },
+  "peerDependencies": {
+    "tree-sitter-cli": "0.24.6"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter-cli": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@ast-grep/nursery": "0.0.2",
+    "tree-sitter-c": "0.23.5",
+    "tree-sitter-cli": "0.24.6"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@ast-grep/lang-c",
+      "tree-sitter-cli"
+    ]
+  }
+}

--- a/packages/c/postinstall.js
+++ b/packages/c/postinstall.js
@@ -1,0 +1,4 @@
+const { postinstall } = require('@ast-grep/setup-lang')
+postinstall({
+  dirname: __dirname,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,22 @@ importers:
         specifier: 0.24.6
         version: 0.24.6
 
+  packages/c:
+    dependencies:
+      '@ast-grep/setup-lang':
+        specifier: 0.0.3
+        version: 0.0.3
+    devDependencies:
+      '@ast-grep/nursery':
+        specifier: 0.0.2
+        version: 0.0.2
+      tree-sitter-c:
+        specifier: 0.23.5
+        version: 0.23.5
+      tree-sitter-cli:
+        specifier: 0.24.6
+        version: 0.24.6
+
   packages/sql:
     dependencies:
       '@ast-grep/setup-lang':
@@ -337,6 +353,14 @@ packages:
       tree_sitter:
         optional: true
 
+  tree-sitter-c@0.23.5:
+    resolution: {integrity: sha512-riDWhqVIt8J14R7G0YMKlUy8E7eYR0Vp6DSGL90nX5CTAXkORCyp4WaOgNtfo8dEsHyZF5e/4E9Z9kWj+qLnTQ==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   tree-sitter-cli@0.24.6:
     resolution: {integrity: sha512-FJ9B1XwXt8Auq75NK/6bpeci7avXSk73OMDq4elXHPS4ue11ZFeCrH/anVN/u5BAZjWqFO9nWGLNEdpdZOg+eA==}
     engines: {node: '>=12.0.0'}
@@ -526,6 +550,11 @@ snapshots:
       node-gyp-build: 4.8.4
       tree-sitter: 0.21.1
       tree-sitter-html: 0.20.4(tree-sitter@0.21.1)
+
+  tree-sitter-c@0.23.5:
+    dependencies:
+      node-addon-api: 8.3.0
+      node-gyp-build: 4.8.4
 
   tree-sitter-cli@0.24.6: {}
 


### PR DESCRIPTION
Steps:

1. create package

```sh
pnpm create @ast-grep/lang packages/c
```

2. answer questions

```
✔ Language name … c
✔ Package name … @ast-grep/lang-c
✔ Tree-sitter package to use … tree-sitter-c
✔ File extensions used by the language, comma separated … c,h
✔ Expando char used in pattern … _
✔ Include gitignore and npm publish files? … no
```

Language configuration can be found  in https://github.com/ast-grep/ast-grep/blob/main/crates/language/src/lib.rs

3. pnpm install /compile

4. add some test case in nursery.js

5. `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added C language support for ast-grep, enabling dynamic language registration and reliable code parsing.
  
- **Documentation**
  - Provided a comprehensive guide with installation instructions and code examples for seamless integration.
  
- **Chores**
  - Streamlined build and post-installation processes to deliver a smoother setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->