### PR TITLE
feat: add lang cpp

### DIFF
--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -14,10 +14,10 @@ pnpm install @tree-sitter/cli --save-dev
 ## Usage
 
 ```js
-import C++ from '@ast-grep/lang-cpp'
+import Cpp from '@ast-grep/lang-cpp'
 import { registerDynamicLanguage, parse } from '@ast-grep/napi'
 
-registerDynamicLanguage({ C++ })
+registerDynamicLanguage({ Cpp })
 
 const sg = parse('C++', `your code`)
 sg.root().kind()

--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -1,0 +1,24 @@
+# ast-grep napi language for C++
+
+## Installation
+
+In a pnpm project, run:
+
+```bash
+pnpm install @ast-grep/lang-cpp
+pnpm install @ast-grep/napi
+# install the tree-sitter-cli if no prebuild is available
+pnpm install @tree-sitter/cli --save-dev
+```
+
+## Usage
+
+```js
+import C++ from '@ast-grep/lang-cpp'
+import { registerDynamicLanguage, parse } from '@ast-grep/napi'
+
+registerDynamicLanguage({ C++ })
+
+const sg = parse('C++', `your code`)
+sg.root().kind()
+```

--- a/packages/cpp/index.d.ts
+++ b/packages/cpp/index.d.ts
@@ -6,5 +6,5 @@ type LanguageRegistration = {
   expandoChar?: string
 }
 
-declare const registratoin: LanguageRegistration
-export default registratoin
+declare const registration: LanguageRegistration
+export default registration

--- a/packages/cpp/index.d.ts
+++ b/packages/cpp/index.d.ts
@@ -1,0 +1,10 @@
+type LanguageRegistration = {
+  libraryPath: string
+  extensions: string[]
+  languageSymbol?: string
+  metaVarChar?: string
+  expandoChar?: string
+}
+
+declare const registratoin: LanguageRegistration
+export default registratoin

--- a/packages/cpp/index.js
+++ b/packages/cpp/index.js
@@ -1,0 +1,9 @@
+const path = require('node:path')
+const libPath = path.join(__dirname, 'parser.so')
+
+module.exports = {
+  libraryPath: libPath,
+  extensions: [".cpp",".cc",".cxx"],
+  languageSymbol: 'tree_sitter_C++',
+  expandoChar: '$',
+}

--- a/packages/cpp/index.js
+++ b/packages/cpp/index.js
@@ -4,6 +4,6 @@ const libPath = path.join(__dirname, 'parser.so')
 module.exports = {
   libraryPath: libPath,
   extensions: [".cpp",".cc",".cxx"],
-  languageSymbol: 'tree_sitter_C++',
-  expandoChar: '$',
+  languageSymbol: 'tree_sitter_cpp',
+  expandoChar: '_',
 }

--- a/packages/cpp/nursery.js
+++ b/packages/cpp/nursery.js
@@ -3,10 +3,24 @@ const languageRegistration = require('./index')
 
 setup({
   dirname: __dirname,
-  name: 'C++',
+  name: 'Cpp',
   treeSitterPackage: 'tree-sitter-cpp',
   languageRegistration,
   testRunner: (parse) => {
-    // add test here
+    const sg = parse(`
+      template <typename T>
+      T add(T a, T b) {
+        return a + b;
+      }
+
+      int main() {
+        int a = 123;
+        int result = add<int>(5, 10);
+        return 0;
+      }
+      `)
+    const root = sg.root()
+    const node = root.find('$T $A = 123')
+    assert.equal(node.kind(), 'declaration')
   }
 })

--- a/packages/cpp/nursery.js
+++ b/packages/cpp/nursery.js
@@ -1,0 +1,12 @@
+const { setup } = require('@ast-grep/nursery')
+const languageRegistration = require('./index')
+
+setup({
+  dirname: __dirname,
+  name: 'C++',
+  treeSitterPackage: 'tree-sitter-cpp',
+  languageRegistration,
+  testRunner: (parse) => {
+    // add test here
+  }
+})

--- a/packages/cpp/package.json
+++ b/packages/cpp/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@ast-grep/lang-cpp",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tree-sitter build -o parser.so",
+    "source": "node nursery.js source",
+    "prepublishOnly": "node nursery.js source",
+    "postinstall": "node postinstall.js",
+    "test": "node nursery.js test"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "type.d.ts",
+    "postinstall.js",
+    "src",
+    "prebuilds"
+  ],
+  "keywords": ["ast-grep"],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@ast-grep/setup-lang": "0.0.3"
+  },
+  "peerDependencies": {
+    "tree-sitter-cli": "0.24.6"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter-cli": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@ast-grep/nursery": "0.0.2",
+    "tree-sitter-cli": "0.24.6"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@ast-grep/lang-cpp",
+      "tree-sitter-cli"
+    ]
+  }
+}

--- a/packages/cpp/postinstall.js
+++ b/packages/cpp/postinstall.js
@@ -1,0 +1,4 @@
+const { postinstall } = require('@ast-grep/setup-lang')
+postinstall({
+  dirname: __dirname,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@ast-grep/setup-lang':
         specifier: 0.0.3
         version: 0.0.3
+      compile:
+        specifier: link:/compile
+        version: link:../../../../compile
     devDependencies:
       '@ast-grep/nursery':
         specifier: 0.0.2
@@ -59,9 +62,6 @@ importers:
       tree-sitter-cli:
         specifier: 0.24.6
         version: 0.24.6
-      tree-sitter-cpp:
-        specifier: 0.23.4
-        version: 0.23.4
 
   packages/sql:
     dependencies:
@@ -382,14 +382,6 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
-  tree-sitter-cpp@0.23.4:
-    resolution: {integrity: sha512-qR5qUDyhZ5jJ6V8/umiBxokRbe89bCGmcq/dk94wI4kN86qfdV8k0GHIUEKaqWgcu42wKal5E97LKpLeVW8sKw==}
-    peerDependencies:
-      tree-sitter: ^0.21.1
-    peerDependenciesMeta:
-      tree-sitter:
-        optional: true
-
   tree-sitter-html@0.20.4:
     resolution: {integrity: sha512-IUE82HgrxGXMiq5xYkAV6VYt+txcqIo4yPUEvq43UIabCKeEUqDOEOmCE9W9mQ2c3392VJEXOPzlpd7VuX1c6Q==}
     peerDependencies:
@@ -581,12 +573,6 @@ snapshots:
       node-gyp-build: 4.8.4
 
   tree-sitter-cli@0.24.6: {}
-
-  tree-sitter-cpp@0.23.4:
-    dependencies:
-      node-addon-api: 8.3.0
-      node-gyp-build: 4.8.4
-      tree-sitter-c: 0.23.5
 
   tree-sitter-html@0.20.4(tree-sitter@0.21.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,22 @@ importers:
         specifier: 0.24.6
         version: 0.24.6
 
+  packages/cpp:
+    dependencies:
+      '@ast-grep/setup-lang':
+        specifier: 0.0.3
+        version: 0.0.3
+    devDependencies:
+      '@ast-grep/nursery':
+        specifier: 0.0.2
+        version: 0.0.2
+      tree-sitter-cli:
+        specifier: 0.24.6
+        version: 0.24.6
+      tree-sitter-cpp:
+        specifier: 0.23.4
+        version: 0.23.4
+
   packages/sql:
     dependencies:
       '@ast-grep/setup-lang':
@@ -366,6 +382,14 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
+  tree-sitter-cpp@0.23.4:
+    resolution: {integrity: sha512-qR5qUDyhZ5jJ6V8/umiBxokRbe89bCGmcq/dk94wI4kN86qfdV8k0GHIUEKaqWgcu42wKal5E97LKpLeVW8sKw==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   tree-sitter-html@0.20.4:
     resolution: {integrity: sha512-IUE82HgrxGXMiq5xYkAV6VYt+txcqIo4yPUEvq43UIabCKeEUqDOEOmCE9W9mQ2c3392VJEXOPzlpd7VuX1c6Q==}
     peerDependencies:
@@ -557,6 +581,12 @@ snapshots:
       node-gyp-build: 4.8.4
 
   tree-sitter-cli@0.24.6: {}
+
+  tree-sitter-cpp@0.23.4:
+    dependencies:
+      node-addon-api: 8.3.0
+      node-gyp-build: 4.8.4
+      tree-sitter-c: 0.23.5
 
   tree-sitter-html@0.20.4(tree-sitter@0.21.1):
     dependencies:


### PR DESCRIPTION
My first attempt at boostraping a new lang, with C++

Trying to follow https://github.com/ast-grep/langs/pull/35, stuck at the step

```
pnpm install /compile
```

as it produces

```
@pelikhan ➜ /workspaces/langs (pelikhan/cpp) $ pnpm install /compile
 ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for C++ language parsing with recognition for common C++ file extensions.
	- Configured a testing environment to ensure smooth integration of C++ language support.

- **Documentation**
	- Added detailed installation and usage instructions for setting up C++ language support.
	- Streamlined the installation process with automated build and post-install scripts. 

- **Refactor**
	- Added new types and constants to enhance language registration functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->