### PR TITLE
✨ PHP

### DIFF
--- a/.changeset/wet-nights-cover.md
+++ b/.changeset/wet-nights-cover.md
@@ -1,0 +1,6 @@
+---
+"@ast-grep/nursery": patch
+"@ast-grep/lang-php": patch
+---
+
+Add @ast-grep/lang-php

--- a/packages/php/README.md
+++ b/packages/php/README.md
@@ -1,0 +1,24 @@
+# ast-grep napi language for php
+
+## Installation
+
+In a pnpm project, run:
+
+```bash
+pnpm install @ast-grep/lang-php
+pnpm install @ast-grep/napi
+# install the tree-sitter-cli if no prebuild is available
+pnpm install @tree-sitter/cli --save-dev
+```
+
+## Usage
+
+```js
+import php from '@ast-grep/lang-php'
+import { registerDynamicLanguage, parse } from '@ast-grep/napi'
+
+registerDynamicLanguage({ php })
+
+const sg = parse('php', `your code`)
+sg.root().kind()
+```

--- a/packages/php/index.d.ts
+++ b/packages/php/index.d.ts
@@ -1,0 +1,10 @@
+type LanguageRegistration = {
+  libraryPath: string
+  extensions: string[]
+  languageSymbol?: string
+  metaVarChar?: string
+  expandoChar?: string
+}
+
+declare const registration: LanguageRegistration
+export default registration

--- a/packages/php/index.js
+++ b/packages/php/index.js
@@ -1,0 +1,9 @@
+const path = require('node:path')
+const libPath = path.join(__dirname, 'parser.so')
+
+module.exports = {
+  libraryPath: libPath,
+  extensions: ['php'],
+  languageSymbol: 'tree_sitter_php',
+  expandoChar: '$',
+}

--- a/packages/php/nursery.js
+++ b/packages/php/nursery.js
@@ -1,4 +1,5 @@
 const { setup } = require('@ast-grep/nursery')
+const assert = require('node:assert')
 const languageRegistration = require('./index')
 const path = require('node:path')
 
@@ -9,6 +10,9 @@ setup({
   src: path.join('php', 'src'),
   languageRegistration,
   testRunner: parse => {
-    // add test here
+    const sg = parse('123')
+    const root = sg.root()
+    const node = root.find('123')
+    assert.equal(node.kind(), 'text')
   },
 })

--- a/packages/php/nursery.js
+++ b/packages/php/nursery.js
@@ -1,0 +1,12 @@
+const { setup } = require('@ast-grep/nursery')
+const languageRegistration = require('./index')
+
+setup({
+  dirname: __dirname,
+  name: 'php',
+  treeSitterPackage: 'tree-sitter-php',
+  languageRegistration,
+  testRunner: parse => {
+    // add test here
+  },
+})

--- a/packages/php/nursery.js
+++ b/packages/php/nursery.js
@@ -1,10 +1,12 @@
 const { setup } = require('@ast-grep/nursery')
 const languageRegistration = require('./index')
+const path = require('node:path')
 
 setup({
   dirname: __dirname,
   name: 'php',
   treeSitterPackage: 'tree-sitter-php',
+  src: path.join('php', 'src'),
   languageRegistration,
   testRunner: parse => {
     // add test here

--- a/packages/php/package.json
+++ b/packages/php/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tree-sitter build -o parser.so",
+    "build": "tree-sitter build -o parser.so ./node_modules/tree-sitter-php/php",
     "source": "node nursery.js source",
     "prepublishOnly": "node nursery.js source",
     "postinstall": "node postinstall.js",
@@ -33,7 +33,7 @@
     }
   },
   "devDependencies": {
-    "@ast-grep/nursery": "0.0.2",
+    "@ast-grep/nursery": "workspace:*",
     "tree-sitter-cli": "0.24.6",
     "tree-sitter-php": "0.23.12"
   },

--- a/packages/php/package.json
+++ b/packages/php/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@ast-grep/lang-php",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tree-sitter build -o parser.so",
+    "source": "node nursery.js source",
+    "prepublishOnly": "node nursery.js source",
+    "postinstall": "node postinstall.js",
+    "test": "node nursery.js test"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "type.d.ts",
+    "postinstall.js",
+    "src",
+    "prebuilds"
+  ],
+  "keywords": ["ast-grep"],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@ast-grep/setup-lang": "0.0.3"
+  },
+  "peerDependencies": {
+    "tree-sitter-cli": "0.24.6"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter-cli": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@ast-grep/nursery": "0.0.2",
+    "tree-sitter-cli": "0.24.6",
+    "tree-sitter-php": "0.23.12"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["@ast-grep/lang-php", "tree-sitter-cli"]
+  }
+}

--- a/packages/php/postinstall.js
+++ b/packages/php/postinstall.js
@@ -1,0 +1,4 @@
+const { postinstall } = require('@ast-grep/setup-lang')
+postinstall({
+  dirname: __dirname,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,8 +281,8 @@ importers:
         version: 0.0.3
     devDependencies:
       '@ast-grep/nursery':
-        specifier: 0.0.2
-        version: 0.0.2
+        specifier: workspace:*
+        version: link:../../scripts/nursery
       tree-sitter-cli:
         specifier: 0.24.6
         version: 0.24.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,22 @@ importers:
         specifier: 2.1.3
         version: 2.1.3
 
+  packages/php:
+    dependencies:
+      '@ast-grep/setup-lang':
+        specifier: 0.0.3
+        version: 0.0.3
+    devDependencies:
+      '@ast-grep/nursery':
+        specifier: 0.0.2
+        version: 0.0.2
+      tree-sitter-cli:
+        specifier: 0.24.6
+        version: 0.24.6
+      tree-sitter-php:
+        specifier: 0.23.12
+        version: 0.23.12(tree-sitter@0.21.1)
+
   packages/python:
     dependencies:
       '@ast-grep/setup-lang':
@@ -1159,6 +1175,14 @@ packages:
   tree-sitter-lua@2.1.3:
     resolution: {integrity: sha512-BmRSRI0Y4J47cE2cODyXsPiueDSAnIrFLJqOP/gKIJhGa4HoGpvEccmNuhAEVGtCrgaHGhaIkWeqiMGCgQ0cfw==}
 
+  tree-sitter-php@0.23.12:
+    resolution: {integrity: sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   tree-sitter-python@0.23.6:
     resolution: {integrity: sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==}
     peerDependencies:
@@ -1907,6 +1931,13 @@ snapshots:
   tree-sitter-lua@2.1.3:
     dependencies:
       nan: 2.22.2
+
+  tree-sitter-php@0.23.12(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.3.1
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
 
   tree-sitter-python@0.23.6:
     dependencies:

--- a/scripts/nursery/index.ts
+++ b/scripts/nursery/index.ts
@@ -22,6 +22,10 @@ interface SetupConfig {
   treeSitterPackage: string
   /** Test cases running in CI */
   testRunner: (parse: (c: string) => SgRoot) => void
+  /** Path of the `src` directory inside the `tree-sitter-*` package. Useful for
+   * `tree-sitter-php`, `tree-sitter-typescript` and `tree-sitter-yaml`.
+   * @default "src" */
+  src?: string
 }
 
 function test(setupConfig: SetupConfig) {
@@ -44,13 +48,15 @@ export function setup(setupConfig: SetupConfig) {
 function copySrcIfNeeded(config: SetupConfig) {
   const { dirname, treeSitterPackage } = config
   const existing = path.join(dirname, 'src')
-  const src = path.join(dirname, 'node_modules', treeSitterPackage, 'src')
+  const src = config.src || 'src'
+  const source = path.join(dirname, 'node_modules', treeSitterPackage, src)
   if (fs.existsSync(existing)) {
     log('src exists, skipping copy')
     return
   }
+
   log('copying tree-sitter src')
-  fs.cpSync(src, 'src', { recursive: true })
+  fs.cpSync(source, 'src', { recursive: true })
 }
 
 interface NodeBasicInfo {


### PR DESCRIPTION
This is a weirder one.

The `tree-sitter-php` package has its `src` folder in [`php`](https://github.com/tree-sitter/tree-sitter-php/tree/master/php) and [`php_only`](https://github.com/tree-sitter/tree-sitter-php/tree/master/php_only) instead of at its root. [`copySrcIfNeeded`](https://github.com/ast-grep/langs/blob/002639cb8b0570afad2b5559a0e23fec0aac5be1/scripts/nursery/index.ts#L44-L54), however, is hard-coded to copy `tree-sitter-*/src`, which doesn't exist.

https://github.com/ast-grep/langs/blob/002639cb8b0570afad2b5559a0e23fec0aac5be1/scripts/nursery/index.ts#L44-L54

This PR adds a `src` parameter to `SetupConfig` to enable the nursery to find the appropriate `src` folder in case it deviates from `src`.

https://github.com/coderabbitai/langs/blob/e8e4b4a097a1650711922e66ec60d8d84cde0b81/scripts/nursery/index.ts#L48-L60

The next issue is that the usual `"build": "tree-sitter build -o parser.so"` script expects the `src` to not reference anything outside of itself, which is an issue for [`scanner.c`](https://github.com/tree-sitter/tree-sitter-php/blob/576a56fa7f8b68c91524cdd211eb2ffc43e7bb11/php/src/scanner.c#L1).

https://github.com/tree-sitter/tree-sitter-php/blob/576a56fa7f8b68c91524cdd211eb2ffc43e7bb11/php/src/scanner.c#L1

I changed it to `tree-sitter build -o parser.so ./node_modules/tree-sitter-php/php`, but then it's not using the `src` folder we just copied and then I have no idea why there's even a `src` folder in the first place if we can directly use `node_modules/tree-sitter-php/php/src` without issues. I notice that [`src` is published](https://github.com/coderabbitai/langs/blob/e8e4b4a097a1650711922e66ec60d8d84cde0b81/packages/php/package.json#L18), but beyond that, I don't know how it's actually used.

This issue affects these languages:

* https://github.com/coderabbitai/langs/pull/16
* https://github.com/coderabbitai/langs/pull/21
* https://github.com/coderabbitai/langs/pull/22
* https://github.com/coderabbitai/langs/pull/23

Since I don't know if this is a good implementation, I'll wait until this one is resolved / merged before adding support for those languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new PHP language support package.
  - Added detailed installation and usage instructions in the README.
  - Enhanced configuration flexibility for managing language source paths.
  - Added new type definitions and constants for language registration.
  - Exported a new object containing properties related to the PHP parser.
  - Included a post-installation setup for the PHP package.

- **Tests**
  - Incorporated a basic test to validate PHP syntax parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->