### PR TITLE
chore(docs): Add specific information about postinstall scripts for PNPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ Packages contain a list of prebuild tree-sitter grammars to use with the `@ast-g
 
 Typical usage:
 
-1. Install the language package in your project
+1. Install the language package in your project.
+
+> [!NOTE]
+> As of [PNPM version 10](https://socket.dev/blog/pnpm-10-0-0-blocks-lifecycle-scripts-by-default), postinstall scripts are no longer run by default. All language packages contain [postinstall](https://github.com/ast-grep/langs/blob/main/scripts/setup/index.ts#L20) scripts that will place the relevant language parsing library in the correct location for the targeted platform. You must explicitly allowlist the postinstall script to run for your desired language package.
 
 ```bash
+# PNPM <v10 - postinstall scripts run by default.
 pnpm install @ast-grep/lang-{name}
+# PNPM v10 and above: Explictly allow the postinstall script to run for this language package
+pnpm install --allow-build=@ast-grep/lang-{name} @ast-grep/lang-{name}
 pnpm install @ast-grep/napi
 # install the tree-sitter-cli if no prebuild is available
-pnpm install @tree-sitter/cli --save-dev
+pnpm install tree-sitter-cli --save-dev
 ```
 
 2. Use the language package in your project


### PR DESCRIPTION
# Context

As of [PNPM version 10](https://socket.dev/blog/pnpm-10-0-0-blocks-lifecycle-scripts-by-default), postinstall scripts are no longer run by default. All language packages contain [postinstall](https://github.com/ast-grep/langs/blob/main/scripts/setup/index.ts#L20) scripts that will place the relevant language parsing library in the correct location for the targeted platform. You must explicitly allowlist the postinstall script to run for your desired language package.

For each language package installed, you can run `pnpm --allow-build=@ast-grep/lang-{lang} add @ast-grep/lang-{lang}` (eg, for the `yaml` package: `pnpm --allow-build=@ast-grep/lang-yaml add @ast-grep/lang-yaml`). If you forget this step, you can approve the build interactively by `pnpm approve-builds` and `pnpm rebuild` to force the post-install script to run. 

# Changes
* Adds documentation for pnpm v10 commands for language packages
* Fixes incorrect package name for `tree-sitter-cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify PNPM v10 behavior changes regarding postinstall scripts.
  * Provided separate example commands for PNPM versions before and after v10.
  * Corrected the package name for installing the tree-sitter CLI.
  * Improved clarity with minor punctuation adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->