### PR TITLE
Fix bundling for multiple platforms

### DIFF
--- a/packages/c/index.js
+++ b/packages/c/index.js
@@ -1,5 +1,30 @@
 const path = require('node:path')
-const libPath = path.join(__dirname, 'parser.so')
+
+function getNativePath() {
+  if (process.platform === 'win32') {
+    if (process.arch === 'x64') {
+      return 'prebuilds/prebuild-Windows-X64/parser.so'
+    }
+
+    throw new Error(`Unsupported architecture on Windows: ${process.arch}`)
+  } else if (process.platform === 'darwin') {
+    if (process.arch === 'arm64') {
+      return 'prebuilds/prebuild-macOS-ARM64/parser.so';
+    }
+
+    throw new Error(`Unsupported architecture on macOS: ${process.arch}`)
+  } else if (process.platform === 'linux') {
+    if (process.arch === 'x64') {
+      return 'prebuilds/prebuild-Linux-X64/parser.so';
+    }
+
+    throw new Error(`Unsupported architecture on Linux: ${process.arch}`)
+  }
+
+  throw new Error(`Unsupported OS: ${process.platform}, architecture: ${process.arch}`)
+}
+
+const libPath = path.join(__dirname, getNativePath())
 
 module.exports = {
   libraryPath: libPath,


### PR DESCRIPTION
This PR follows up on the issue raised here: https://github.com/ast-grep/ast-grep/discussions/2146.

Currently, the packages assume that `./parser.so` is compatible with the system architecture when running the app.
This assumption breaks when the app is bundled to run on multiple platforms.

In my case, I’m using `@ast-grep/lang-c` in a VS Code extension and need a bundle that works for both ARM and x86 architectures.

As a solution, I updated `packages/c/index.js` to load `parser.so` from the `prebuilds` folder based on `process.platform` and `process.arch`, similar to how [`requireNative` in `@ast-grep/napi`](https://github.com/ast-grep/ast-grep/blob/d9cefc99e954636c93ad28618a1cd18ee2a271d4/crates/napi/index.js#L66) works.

**Notes:**
This PR is an MVP to resolve my immediate issue and unblock release for some users.
It currently only addresses `@ast-grep/lang-c`.
The extra copy of parser.so should be removed in a proper implementation.
Intended as a proof-of-concept rather than a merge-ready fix.