### PR TITLE
feat: add gdscript language package

### DIFF
--- a/.changeset/add-gdscript.md
+++ b/.changeset/add-gdscript.md
@@ -1,0 +1,5 @@
+---
+"@ast-grep/lang-gdscript": patch
+---
+
+Add a language package for GDScript, backed by tree-sitter-gdscript.

--- a/packages/gdscript/README.md
+++ b/packages/gdscript/README.md
@@ -1,0 +1,24 @@
+# ast-grep napi language for gdscript
+
+## Installation
+
+In a pnpm project, run:
+
+```bash
+pnpm install @ast-grep/lang-gdscript
+pnpm install @ast-grep/napi
+# install the tree-sitter-cli if no prebuild is available
+pnpm install tree-sitter-cli --save-dev
+```
+
+## Usage
+
+```js
+import gdscript from '@ast-grep/lang-gdscript'
+import { registerDynamicLanguage, parse } from '@ast-grep/napi'
+
+registerDynamicLanguage({ gdscript })
+
+const sg = parse('gdscript', `your code`)
+sg.root().kind()
+```

--- a/packages/gdscript/README.md
+++ b/packages/gdscript/README.md
@@ -6,10 +6,15 @@ In a pnpm project, run:
 
 ```bash
 pnpm install @ast-grep/lang-gdscript
+# pnpm v10 and above block postinstall scripts, so allow this one explicitly
+pnpm install --allow-build=@ast-grep/lang-gdscript @ast-grep/lang-gdscript
 pnpm install @ast-grep/napi
 # install the tree-sitter-cli if no prebuild is available
 pnpm install tree-sitter-cli --save-dev
 ```
+
+The postinstall script places the parser library for your platform. If it does not
+run and no prebuild is bundled, `parser.so` is never built and `libraryPath` throws.
 
 ## Usage
 
@@ -21,4 +26,27 @@ registerDynamicLanguage({ gdscript })
 
 const sg = parse('gdscript', `your code`)
 sg.root().kind()
+```
+
+## expandoChar and leading-underscore identifiers
+
+This package uses `expandoChar: '_'`, because tree-sitter-gdscript accepts only
+ASCII identifiers and a non-ASCII expando char fails to parse.
+
+The cost is that a pattern containing a literal leading-underscore ALL-CAPS
+identifier is read as a metavariable. That spelling is GDScript's private-constant
+convention, so `_MAX_SPEED` as a pattern matches every node rather than that one
+constant. Lowercase identifiers, including `_init` and `_process`, are unaffected.
+
+To match such an identifier literally, use a rule with `regex` instead of a pattern.
+A declaration binds it as `name` and a use as `identifier`, so match both:
+
+```yaml
+id: literal-const
+language: gdscript
+rule:
+  regex: ^_MAX_SPEED$
+  any:
+    - kind: identifier
+    - kind: name
 ```

--- a/packages/gdscript/index.d.ts
+++ b/packages/gdscript/index.d.ts
@@ -1,0 +1,10 @@
+type LanguageRegistration = {
+  libraryPath: string
+  extensions: string[]
+  languageSymbol?: string
+  metaVarChar?: string
+  expandoChar?: string
+}
+
+declare const registration: LanguageRegistration
+export = registration

--- a/packages/gdscript/index.js
+++ b/packages/gdscript/index.js
@@ -1,0 +1,31 @@
+const path = require('node:path')
+const fs = require('node:fs')
+const { resolvePrebuild } = require('@ast-grep/setup-lang')
+
+function getLibPath() {
+  const prebuild = resolvePrebuild(__dirname)
+  if (prebuild) {
+    return prebuild
+  }
+
+  const native = path.join(__dirname, 'parser.so')
+  if (fs.existsSync(native)) {
+    return native
+  }
+
+  throw new Error('No parser found. Please ensure the parser is built or a prebuild is available.')
+}
+
+let libPath
+
+module.exports = {
+  get libraryPath() {
+    if (!libPath) {
+      libPath = getLibPath()
+    }
+    return libPath
+  },
+  extensions: ['gd'],
+  languageSymbol: 'tree_sitter_gdscript',
+  expandoChar: '_',
+}

--- a/packages/gdscript/nursery.js
+++ b/packages/gdscript/nursery.js
@@ -1,0 +1,16 @@
+const { setup } = require('@ast-grep/nursery')
+const assert = require('node:assert')
+const languageRegistration = require('./index')
+
+setup({
+  dirname: __dirname,
+  name: 'gdscript',
+  treeSitterPackage: 'tree-sitter-gdscript',
+  languageRegistration,
+  testRunner: parse => {
+    const sg = parse('print(123)')
+    const root = sg.root()
+    const node = root.find('print($A)')
+    assert.equal(node.kind(), 'call')
+  },
+})

--- a/packages/gdscript/package.json
+++ b/packages/gdscript/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@ast-grep/lang-gdscript",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tree-sitter build -o parser.so",
+    "source": "node nursery.js source",
+    "prepublishOnly": "node nursery.js source",
+    "postinstall": "node postinstall.js",
+    "test": "node nursery.js test"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "type.d.ts",
+    "postinstall.js",
+    "src",
+    "prebuilds"
+  ],
+  "keywords": ["ast-grep", "ast-grep-lang"],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@ast-grep/setup-lang": "0.0.6"
+  },
+  "peerDependencies": {
+    "tree-sitter-cli": "0.26.7"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter-cli": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@ast-grep/nursery": "0.0.9",
+    "tree-sitter-cli": "0.26.7",
+    "tree-sitter-gdscript": "6.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["@ast-grep/lang-gdscript", "tree-sitter-cli"]
+  }
+}

--- a/packages/gdscript/postinstall.js
+++ b/packages/gdscript/postinstall.js
@@ -1,0 +1,4 @@
+const { postinstall } = require('@ast-grep/setup-lang')
+postinstall({
+  dirname: __dirname,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 0.0.9
       tree-sitter-bicep:
         specifier: 1.1.0
-        version: 1.1.0
+        version: 1.1.0(tree-sitter@0.22.4)
       tree-sitter-cli:
         specifier: 0.26.7
         version: 0.26.7
@@ -80,7 +80,7 @@ importers:
         version: 0.0.9
       tree-sitter-c:
         specifier: 0.24.1
-        version: 0.24.1
+        version: 0.24.1(tree-sitter@0.22.4)
       tree-sitter-cli:
         specifier: 0.26.7
         version: 0.26.7
@@ -164,6 +164,22 @@ importers:
       tree-sitter-elixir:
         specifier: 0.3.5
         version: 0.3.5(tree-sitter@0.21.1)
+
+  packages/gdscript:
+    dependencies:
+      '@ast-grep/setup-lang':
+        specifier: 0.0.6
+        version: 0.0.6
+    devDependencies:
+      '@ast-grep/nursery':
+        specifier: 0.0.9
+        version: 0.0.9
+      tree-sitter-cli:
+        specifier: 0.26.7
+        version: 0.26.7
+      tree-sitter-gdscript:
+        specifier: 6.1.0
+        version: 6.1.0(tree-sitter@0.21.1)
 
   packages/glimmer-javascript:
     dependencies:
@@ -320,7 +336,7 @@ importers:
         version: 0.0.9
       '@tree-sitter-grammars/tree-sitter-lua':
         specifier: 0.4.1
-        version: 0.4.1
+        version: 0.4.1(tree-sitter@0.22.4)
       tree-sitter-cli:
         specifier: 0.26.7
         version: 0.26.7
@@ -355,7 +371,7 @@ importers:
         version: 0.26.7
       tree-sitter-php:
         specifier: 0.24.2
-        version: 0.24.2
+        version: 0.24.2(tree-sitter@0.22.4)
 
   packages/python:
     dependencies:
@@ -403,7 +419,7 @@ importers:
         version: 0.26.7
       tree-sitter-rust:
         specifier: 0.23.2
-        version: 0.23.2
+        version: 0.23.2(tree-sitter@0.22.4)
 
   packages/scala:
     dependencies:
@@ -451,7 +467,7 @@ importers:
         version: 0.26.7
       tree-sitter-swift:
         specifier: 0.7.1
-        version: 0.7.1(tree-sitter@0.21.1)
+        version: 0.7.1(tree-sitter@0.22.4)
 
   packages/toml:
     dependencies:
@@ -464,7 +480,7 @@ importers:
         version: link:../../scripts/nursery
       '@tree-sitter-grammars/tree-sitter-toml':
         specifier: 0.7.0
-        version: 0.7.0
+        version: 0.7.0(tree-sitter@0.22.4)
       tree-sitter-cli:
         specifier: 0.26.7
         version: 0.26.7
@@ -512,7 +528,7 @@ importers:
         version: 0.0.9
       '@tree-sitter-grammars/tree-sitter-yaml':
         specifier: 0.7.1
-        version: 0.7.1
+        version: 0.7.1(tree-sitter@0.22.4)
       tree-sitter-cli:
         specifier: 0.26.7
         version: 0.26.7
@@ -1420,6 +1436,14 @@ packages:
     peerDependencies:
       tree-sitter: ^0.21.0
 
+  tree-sitter-gdscript@6.1.0:
+    resolution: {integrity: sha512-Uy5+GWLkec2JaS1mamiJYsC9j/JoW2FxFq4bnji95gyTtMTsqO6+RSVIaBTU/vRGSNEi3PVDZzyV0j3B4RdntA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   tree-sitter-glimmer-javascript@0.2.0:
     resolution: {integrity: sha512-2EkpfYxsfNGWuGx3CmNRibkBMe739wtHLiRaQSsjXn3te8Ugk1lcqj3ZYAlwdid+ywe4+5nbc4ZsiJbeRIc2qw==}
     peerDependencies:
@@ -1562,6 +1586,9 @@ packages:
 
   tree-sitter@0.21.1:
     resolution: {integrity: sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==}
+
+  tree-sitter@0.22.4:
+    resolution: {integrity: sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1954,10 +1981,12 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.67.0':
     optional: true
 
-  '@tree-sitter-grammars/tree-sitter-lua@0.4.1':
+  '@tree-sitter-grammars/tree-sitter-lua@0.4.1(tree-sitter@0.22.4)':
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
   '@tree-sitter-grammars/tree-sitter-markdown@0.3.2(tree-sitter@0.21.1)':
     dependencies:
@@ -1965,15 +1994,19 @@ snapshots:
       node-gyp-build: 4.8.4
       tree-sitter: 0.21.1
 
-  '@tree-sitter-grammars/tree-sitter-toml@0.7.0':
+  '@tree-sitter-grammars/tree-sitter-toml@0.7.0(tree-sitter@0.22.4)':
     dependencies:
       node-addon-api: 8.3.0
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
-  '@tree-sitter-grammars/tree-sitter-yaml@0.7.1':
+  '@tree-sitter-grammars/tree-sitter-yaml@0.7.1(tree-sitter@0.22.4)':
     dependencies:
       node-addon-api: 8.3.1
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
   '@types/node@12.20.55': {}
 
@@ -2294,10 +2327,12 @@ snapshots:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
 
-  tree-sitter-bicep@1.1.0:
+  tree-sitter-bicep@1.1.0(tree-sitter@0.22.4):
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
   tree-sitter-c-sharp@0.23.5:
     dependencies:
@@ -2309,10 +2344,12 @@ snapshots:
       node-addon-api: 8.8.0
       node-gyp-build: 4.8.4
 
-  tree-sitter-c@0.24.1:
+  tree-sitter-c@0.24.1(tree-sitter@0.22.4):
     dependencies:
       node-addon-api: 8.3.1
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
   tree-sitter-cli@0.23.2: {}
 
@@ -2337,6 +2374,13 @@ snapshots:
     dependencies:
       node-addon-api: 7.1.1
       node-gyp-build: 4.8.4
+      tree-sitter: 0.21.1
+
+  tree-sitter-gdscript@6.1.0(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.8.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
       tree-sitter: 0.21.1
 
   tree-sitter-glimmer-javascript@0.2.0(tree-sitter@0.21.1):
@@ -2402,10 +2446,12 @@ snapshots:
       node-gyp-build: 4.8.4
       tree-sitter: 0.21.1
 
-  tree-sitter-php@0.24.2:
+  tree-sitter-php@0.24.2(tree-sitter@0.22.4):
     dependencies:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
   tree-sitter-python@0.25.0:
     dependencies:
@@ -2419,10 +2465,12 @@ snapshots:
     optionalDependencies:
       tree-sitter: 0.21.1
 
-  tree-sitter-rust@0.23.2:
+  tree-sitter-rust@0.23.2(tree-sitter@0.22.4):
     dependencies:
       node-addon-api: 8.3.1
       node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.22.4
 
   tree-sitter-scala@0.24.0(tree-sitter@0.21.1):
     dependencies:
@@ -2431,11 +2479,11 @@ snapshots:
     optionalDependencies:
       tree-sitter: 0.21.1
 
-  tree-sitter-swift@0.7.1(tree-sitter@0.21.1):
+  tree-sitter-swift@0.7.1(tree-sitter@0.22.4):
     dependencies:
       node-addon-api: 8.3.1
       node-gyp-build: 4.8.4
-      tree-sitter: 0.21.1
+      tree-sitter: 0.22.4
       tree-sitter-cli: 0.23.2
       which: 2.0.2
 
@@ -2448,6 +2496,11 @@ snapshots:
       tree-sitter: 0.21.1
 
   tree-sitter@0.21.1:
+    dependencies:
+      node-addon-api: 8.8.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter@0.22.4:
     dependencies:
       node-addon-api: 8.8.0
       node-gyp-build: 4.8.4


### PR DESCRIPTION
ast-grep has no GDScript and the core repo's popularity gate rules it out, so here it is as a package. Grammar pinned at tree-sitter-gdscript 6.1.0.

One thing worth a reviewer's eye: expandoChar has to be `_`. A non-ASCII char like kotlin's `µ` fails to parse, because tree-sitter-gdscript identifiers are ASCII only. The cost of `_` is that a pattern containing a literal leading-underscore ALL-CAPS identifier gets read as a metavariable — that spelling is GDScript's private-const convention, so a pattern like `_MAX_SPEED` matches everything instead of that one constant. Lowercase identifiers, `_init` and `_process` included, are unaffected. The README documents this with a regex-rule workaround for matching such an identifier literally.

build, test, lint:ci and format:ci pass on pnpm 9.