### PR TITLE
fix: sanitize shell/subprocess call in index.ts

### DIFF
--- a/scripts/create-lang/index.ts
+++ b/scripts/create-lang/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import prompts from 'prompts'
@@ -113,9 +113,11 @@ async function renameFiles(dir: string, answer: Answers) {
 }
 function installTreeSitterPackage(cwd: string, answer: Answers) {
   console.log('Installing tree-sitter package...')
-  execSync(`pnpm install ${answer.treeSitterPackage} --save-dev --save-exact`, {
-    cwd,
-  })
+  execFileSync(
+    'pnpm',
+    ['install', answer.treeSitterPackage, '--save-dev', '--save-exact'],
+    { cwd },
+  )
   console.log('Copying source code...')
   execSync('pnpm run source', { cwd })
   console.log('Compiling')


### PR DESCRIPTION
## Summary
Address critical severity security finding in `scripts/create-lang/index.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/create-lang/index.ts:100` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The installTreeSitterPackage function uses execSync with template literal interpolation of answer.treeSitterPackage, which is user input collected via the prompts library. While there is validation via isValidPackageName() regex, the regex allows characters like '*', '~', '.', '_', and '-' which can be exploited in shell contexts. The execSync function invokes a shell by default, allowing command injection through specially crafted package names.

## Evidence

**Exploitation scenario**: An attacker provides a malicious package name like '$(whoami)' or '; rm -rf / #' through the prompts interface.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `scripts/create-lang/index.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved package installation handling when generating language support by using safer command execution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->